### PR TITLE
legacyjailbreak: inform that TaiG doesn't actually work

### DIFF
--- a/pages/legacyjailbreak.html
+++ b/pages/legacyjailbreak.html
@@ -86,13 +86,14 @@
         <p>Supported: iOS 8.4.1</p>
         <p>32-bit devices only</p>
         <br>
-        <a href="http://www.taig.com/en/">Taig</a>
+        <a href="http://www.taig.com/en/">TaiG</a>
         <p>Supported: iOS 8.0 - 8.4</p>
         <p>Both 32-bit and 64-bit devices</p>
         <p>Note: The official website is down.<br>
         Mirror can be found at 
         <a href="https://mega.nz/folder/k4FAXCIB%23Fk7pxs6ikYzL3YBvAGX5ig">
         The Legacy Archives</a></p>
+        <p>As TaiG servers are down, the program will not work as expected.</p>
         <br>
         <a href="http://ghost.25pp.com">PP Jailbreak</a>
         <p>Supported: iOS 8.0 - 8.4</p>


### PR DESCRIPTION
TaiG does not work anymore as their servers are gone. The program doesn't even boot when attempting to do so, as the first thing it does is check the servers that don't exist and then doesn't go any further from there.

It appears PPJailbreak is the same, but there have been sources that mention different things in the past 4 months so I think we can leave that alone for now.
